### PR TITLE
Fix: layout indeed can be longer the samples

### DIFF
--- a/R/classes-model.R
+++ b/R/classes-model.R
@@ -296,6 +296,7 @@ create_standard_curve_model_analyte <- function(plate, analyte_name, data_type =
 
   mfi_source <- ifelse(source_mfi_range_from_all_analytes, "ALL", analyte_name)
 
+
   mfi_min <- min(plate$get_data(mfi_source, "STANDARD CURVE", data_type = data_type), na.rm = TRUE)
   mfi_max <- max(plate$get_data(mfi_source, "STANDARD CURVE", data_type = data_type), na.rm = TRUE)
 

--- a/R/classes-plate_builder.R
+++ b/R/classes-plate_builder.R
@@ -433,13 +433,14 @@ convert_dilutions_to_numeric <- function(dilutions) {
 #'
 #' Otherwise, the returned SampleType is `TEST`
 #'
-#' @param sample_names (`character`)\cr
+#' @param sample_names (`character()`)\cr
 #' Vector of sample names from Luminex file
 #'
-#' @param sample_names_from_layout (`character`)\cr
+#' @param sample_names_from_layout (`character()`)\cr
 #' Vector of sample names from Layout file
 #' values in this vector may be different than `sample_names` and may
-#' contain additional information about the sample type like dilution
+#' contain additional information about the sample type like dilution.
+#' This vector when set has to have at least the length of `sample_names`.
 #'
 #' @return A vector of valid sample_type strings of length equal to the length of `sample_names`
 #'
@@ -448,12 +449,15 @@ convert_dilutions_to_numeric <- function(dilutions) {
 #' translate_sample_names_to_sample_types(c("S", "CP3"))
 #'
 #' @export
-translate_sample_names_to_sample_types <- function(sample_names, sample_names_from_layout = "") {
+translate_sample_names_to_sample_types <- function(sample_names, sample_names_from_layout = NULL) {
+  stopifnot(is.character(sample_names))
   # Handle case when sample name from layout is not provided
-  # Ensure sample_names_from_layout is a character vector of the same length as sample_names
-  if (length(sample_names_from_layout) != length(sample_names)) {
+  if (is.null(sample_names_from_layout)) {
     sample_names_from_layout <- rep("", length(sample_names))
   }
+  # Ensure sample_names_from_layout is a character vector at least as long as sample_names
+  stopifnot(length(sample_names) <= length(sample_names_from_layout))
+
   # Initialize the result vector
   sample_types <- vector("character", length(sample_names))
   # Iterate over each sample

--- a/R/parser.R
+++ b/R/parser.R
@@ -190,7 +190,6 @@ read_luminex_data <- function(plate_filepath,
   plate_builder$set_dilutions(use_layout_dilutions, dilutions)
 
 
-
   plate <- plate_builder$build(validate = TRUE)
 
   verbose_cat(color_codes$green_start, "\nNew plate object has been created with name: ",

--- a/man/translate_sample_names_to_sample_types.Rd
+++ b/man/translate_sample_names_to_sample_types.Rd
@@ -6,17 +6,18 @@
 \usage{
 translate_sample_names_to_sample_types(
   sample_names,
-  sample_names_from_layout = ""
+  sample_names_from_layout = NULL
 )
 }
 \arguments{
-\item{sample_names}{(\code{character})\cr
+\item{sample_names}{(\code{character()})\cr
 Vector of sample names from Luminex file}
 
-\item{sample_names_from_layout}{(\code{character})\cr
+\item{sample_names_from_layout}{(\code{character()})\cr
 Vector of sample names from Layout file
 values in this vector may be different than \code{sample_names} and may
-contain additional information about the sample type like dilution}
+contain additional information about the sample type like dilution.
+This vector when set has to have at least the length of \code{sample_names}.}
 }
 \value{
 A vector of valid sample_type strings of length equal to the length of \code{sample_names}

--- a/tests/testthat/test-plate_builder.R
+++ b/tests/testthat/test-plate_builder.R
@@ -70,6 +70,16 @@ test_that("Sample type is correctly identified as POSITIVE CONTROL", {
   )
 })
 
+test_that("Test translating samples with only proportions", {
+  expect_equal(
+    translate_sample_names_to_sample_types(
+      c("BLANK", "1/50", "1/100", "1/1000"),
+      c("BLANK", "1/50", "1/100", "1/1000")
+    ),
+    c("BLANK", "STANDARD CURVE", "STANDARD CURVE", "STANDARD CURVE")
+  )
+})
+
 test_that("Sample type defaults to TEST when no special conditions are met", {
   expect_equal(
     translate_sample_names_to_sample_types(
@@ -85,14 +95,6 @@ test_that("Handling of missing layout names", {
     translate_sample_names_to_sample_types(
       c("BLANK", "S", "POS 1/10", "NEGATIVE CONTROL"),
       NULL
-    ),
-    c("BLANK", "STANDARD CURVE", "POSITIVE CONTROL", "NEGATIVE CONTROL")
-  )
-
-  expect_equal(
-    translate_sample_names_to_sample_types(
-      c("BLANK", "S", "POS 1/10", "NEGATIVE CONTROL"),
-      NA
     ),
     c("BLANK", "STANDARD CURVE", "POSITIVE CONTROL", "NEGATIVE CONTROL")
   )


### PR DESCRIPTION
I tried running the program with the `CovidOISExPONTENT_CO.csv` plate and layout and encountered an error.
After investigating the length of the layout_names can in fact be bigger then the number of samples. Simply said one can have a not fully complete plate.

The code had a check for a case when the number of sample names and the number of layout names miss-align and removed the information for the layout names completely. This resulted in the plate not having any STANDARD CURVE samples and should be captured in the validation step of loading the plate. I have created an issue for that: #108

This PR fixes the translation bug