### PR TITLE
Nplr warnings

### DIFF
--- a/R/classes-model.R
+++ b/R/classes-model.R
@@ -191,7 +191,7 @@ Model <- R6::R6Class(
       private$assert_model_fitted()
       upper_bound <- nplr::getPar(self$model)$params$top
       upper_bound <- (upper_bound + 1) / 2
-      lower_bound <- private$mfi_transform(5) # Scaled MFI for MFI = 5
+      lower_bound <- private$mfi_transform(10) # Scaled MFI for MFI = 10
 
       uniform_targets <- seq(lower_bound, upper_bound, length.out = 100)
       df <- nplr::getEstimates(self$model, targets = uniform_targets)

--- a/R/parser.R
+++ b/R/parser.R
@@ -80,11 +80,11 @@ handle_datetime <- function(datetime_str, file_format = "xPONENT") {
   if (!is.na(first_attempt)) {
     return(first_attempt)
   } else {
-    warning("Could not parse datetime string using default datetime format. Trying other possibilies.")
+    message("Could not parse datetime string using default datetime format. Trying other possibilies.")
     for (order in possible_orders[-1]) {
       datetime <- lubridate::parse_date_time2(datetime_str, orders = order, tz = "")
       if (!is.na(datetime)) {
-        warning("Successfully parsed datetime string using order: ", order)
+        message("Successfully parsed datetime string using order: ", order)
         return(datetime)
       }
     }

--- a/man/Model.Rd
+++ b/man/Model.Rd
@@ -154,7 +154,7 @@ Use values before any transformations (e.g., before the \code{log10} transformat
 \subsection{Method \code{predict()}}{
 Predict RAU values from the MFI values
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Model$predict(mfi, over_max_extrapolation = 0)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Model$predict(mfi, over_max_extrapolation = 0, eps = 0.000001)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -168,6 +168,9 @@ How much we can extrapolate the values above the maximum RAU value
 seen in standard curve samples \eqn{RAU_{max}}. Defaults to 0.
 If the value of the predicted RAU is above \eqn{RAU_{max} + \text{over_max_extrapolation}},
 the value is censored to the value of that sum.}
+
+\item{\code{eps}}{(\code{numeric(1)})\cr
+A small value used to avoid numerical issues close to the asymptotes}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-parser.R
+++ b/tests/testthat/test-parser.R
@@ -8,7 +8,7 @@ test_that("Test handle_datetime with seen date formats", {
   )
 
   # Automatic recovery with xPONENT datetime format DD/MM/YYYY HH:MM
-  expect_warning(dt <- handle_datetime("26/02/2014 16:07", "xPONENT"))
+  expect_message(dt <- handle_datetime("26/02/2014 16:07", "xPONENT"))
   expect_equal(dt, as.POSIXct("2014-02-26 16:07:00", tz = ""))
 
   # Default INTELLIFLEX datetime format YYYY-MM-DD HH:MM:SS AM/PM

--- a/tests/testthat/test-standard_curve.R
+++ b/tests/testthat/test-standard_curve.R
@@ -39,3 +39,12 @@ test_that("Test plotting the full plot", {
   model <- create_standard_curve_model_analyte(plate, "Spike_6P_IPP")
   expect_no_error(plot_standard_curve_analyte_with_model(plate, model))
 })
+
+test_that("Test over max extrapolation", {
+  plate <- get_test_plate()
+  model <- create_standard_curve_model_analyte(plate, "Spike_6P_IPP")
+  expect_warning(plot_standard_curve_analyte_with_model(
+    plate, model,
+    over_max_extrapolation = Inf
+  ))
+})


### PR DESCRIPTION
This PR resolves prevents the nplr out off bounds errors from happening by manually handling the edge cases.
Also this PR changes the `handle_datetime` method from raising warning to emitting a message