### PR TITLE
Show less of process_plate df 

### DIFF
--- a/R/process-plate.R
+++ b/R/process-plate.R
@@ -112,7 +112,7 @@ process_plate <-
 
       test_sample_names <-
         plate$sample_names[plate$sample_types == "TEST"]
-      output_list <- list("SampleName" = test_sample_names)
+      output_list <- list()
       verbose_cat("Fitting the models and predicting RAU for each analyte\n",
         verbose = verbose
       )
@@ -127,7 +127,6 @@ process_plate <-
       }
 
       output_df <- data.frame(output_list)
-
       rownames(output_df) <- test_sample_names
     }
 

--- a/vignettes/example_script.Rmd
+++ b/vignettes/example_script.Rmd
@@ -53,7 +53,13 @@ The computed RAU values are then saved to a CSV file.
 ```{r}
 tmp_dir <- tempdir(check = TRUE)
 test_output_path <- file.path(tmp_dir, "output.csv")
-process_plate(plate, output_path = test_output_path)
+df <- process_plate(plate, output_path = test_output_path)
+colnames(df)
+```
+
+We can take a look at a slice of the produced dataframe (as not to overcrowd the article).
+```{r}
+df[1:5, 1:5]
 ```
 
 ## Quality control and normalisation details
@@ -230,6 +236,7 @@ nmfi_values <- get_nmfi(plate)
 # process plate with nMFI normalisation
 
 nmfi_output_path <- file.path(tmp_dir, "nmfi_output.csv")
-process_plate(plate, output_path = nmfi_output_path, normalisation_type = "nMFI")
+df <- process_plate(plate, output_path = nmfi_output_path, normalisation_type = "nMFI")
+df[1:5, 1:5]
 ```
 


### PR DESCRIPTION
Show a smaller portion of the df resulting from calling the `process_plate` function in the vignettes as not to overcrowd the vignette itself