### PR TITLE
fix: less restrictive process dir paths

### DIFF
--- a/R/process-dir.R
+++ b/R/process-dir.R
@@ -57,7 +57,7 @@ find_layout_file <- function(plate_filepath, layout_filepath = NULL) {
 #'
 is_mba_data_file <- function(filepath, check_format = TRUE) {
   format_pattern <- PvSTATEM.env$mba_pattern
-  extension_pattern <- "\\.(xlsx|csv)$"
+  extension_pattern <- "\\.([xX][lL][sS][xX]|[cC][sS][vV])$"
   output_pattern <- "RAU|nMFI"
   layout_pattern <- "_layout"
 


### PR DESCRIPTION
The regex for detecting MBA files was to restrictive and didn't allow capitalisation of extensions. Now that is changed to detect such files:

![image](https://github.com/user-attachments/assets/bbfd031b-3e47-4538-b428-88564cb20af9)
